### PR TITLE
Catch unhandled protocol exceptions (caused by mopidy)

### DIFF
--- a/osxmpdkeys/client.py
+++ b/osxmpdkeys/client.py
@@ -11,7 +11,14 @@ class Client(object):
         mpdc.timeout = 3
 
         def perform(fn):
-            fn() if self._connected else self._queue.append(fn)
+            try:
+                fn() if self._connected else self._queue.append(fn)
+            except mpd.ProtocolError as exc:
+                print(
+                    "Got an exception while excuting command '%s': %s" % (
+                        fn.__name__, exc
+                    )
+                )
             return False
 
         def play_pause():


### PR DESCRIPTION
It seems that the mopidy handles
some of the MPD commands different than an 'original'
MPD server. This fix does not solve that (obviously),
but at least it prevents the module from crashing.
