### PR TITLE
Log and ignore all python-mpd2 exceptions

### DIFF
--- a/osxmpdkeys/client.py
+++ b/osxmpdkeys/client.py
@@ -13,7 +13,7 @@ class Client(object):
         def perform(fn):
             try:
                 fn() if self._connected else self._queue.append(fn)
-            except mpd.ProtocolError as exc:
+            except mpd.MPDError as exc:
                 print(
                     "Got an exception while executing command '%s': %s" % (
                         fn.__name__, exc


### PR DESCRIPTION
The app crashes when the playlist is empty and the play/pause key is pressed. This results in the app entering a running, but unusable state that fails to register any more key presses.

This pull request changes the existing except/log behavior to handle the base class of all `python-mpd2` exceptions.

**Traceback**
```
$ mpdkeys
Connecting...
Connected.
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/Users/andrewr/.local/git/pyenv/versions/3.7.1/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/Users/andrewr/Code/osxmmkeys/osxmmkeys/tap.py", line 51, in run
    Quartz.CFRunLoopRun()  # Only returns after stop() is called.
  File "/Users/andrewr/Code/osxmmkeys/osxmmkeys/tap.py", line 60, in _handle_event_tap
    if not self._handle_event(ns_event):
  File "/Users/andrewr/Code/osxmmkeys/osxmmkeys/tap.py", line 75, in _handle_event
    if handler() == False:
  File "/Users/andrewr/.local/share/virtualenvs/07138e55a04dc6cf7b1b4d84c2efbac8dff8434d53d2217162b99055eb13fee8/lib/python3.7/site-packages/osxmpdkeys/client.py", line 38, in <lambda>
    tap.on('play_pause', lambda: perform(play_pause))
  File "/Users/andrewr/.local/share/virtualenvs/07138e55a04dc6cf7b1b4d84c2efbac8dff8434d53d2217162b99055eb13fee8/lib/python3.7/site-packages/osxmpdkeys/client.py", line 15, in perform
    fn() if self._connected else self._queue.append(fn)
  File "/Users/andrewr/.local/share/virtualenvs/07138e55a04dc6cf7b1b4d84c2efbac8dff8434d53d2217162b99055eb13fee8/lib/python3.7/site-packages/osxmpdkeys/client.py", line 28, in play_pause
    mpdc.play(status.get('song', 0))
  File "/Users/andrewr/.local/share/virtualenvs/07138e55a04dc6cf7b1b4d84c2efbac8dff8434d53d2217162b99055eb13fee8/lib/python3.7/site-packages/mpd/base.py", line 381, in mpd_command
    return wrapper(self, name, args, callback)
  File "/Users/andrewr/.local/share/virtualenvs/07138e55a04dc6cf7b1b4d84c2efbac8dff8434d53d2217162b99055eb13fee8/lib/python3.7/site-packages/mpd/base.py", line 473, in _execute
    return retval()
  File "/Users/andrewr/.local/share/virtualenvs/07138e55a04dc6cf7b1b4d84c2efbac8dff8434d53d2217162b99055eb13fee8/lib/python3.7/site-packages/mpd/base.py", line 368, in command_callback
    res = function(self, self._read_lines())
  File "/Users/andrewr/.local/share/virtualenvs/07138e55a04dc6cf7b1b4d84c2efbac8dff8434d53d2217162b99055eb13fee8/lib/python3.7/site-packages/mpd/base.py", line 311, in _parse_nothing
    for line in lines:
  File "/Users/andrewr/.local/share/virtualenvs/07138e55a04dc6cf7b1b4d84c2efbac8dff8434d53d2217162b99055eb13fee8/lib/python3.7/site-packages/mpd/base.py", line 538, in _read_lines
    line = self._read_line()
  File "/Users/andrewr/.local/share/virtualenvs/07138e55a04dc6cf7b1b4d84c2efbac8dff8434d53d2217162b99055eb13fee8/lib/python3.7/site-packages/mpd/base.py", line 527, in _read_line
    raise CommandError(error)
mpd.base.CommandError: [2@0] {} Bad song index
```

his pull request changes the existing except/log behavior to handle the base class of all `python-mpd2` errors.